### PR TITLE
Works around debug map endpoint pass-through

### DIFF
--- a/debug/index.html
+++ b/debug/index.html
@@ -125,7 +125,7 @@ var simple = {
         },
         "osrm": {
             "type": "vector",
-            "tiles" : ["https://routing2.openstreetmap.de/routed-car/tile/v1/car/tile({x},{y},{z}).mvt"]
+            "tiles" : ["http://routing2.openstreetmap.de:3332/tile/v1/car/tile({x},{y},{z}).mvt"]
         }
     },
     "glyphs": "mapbox://fonts/mapbox/{fontstack}/{range}.pbf",


### PR DESCRIPTION
At the moment the Apache config is not correctly set up to pass through tile endpoint requests. This changeset works around this limitation by directly accessing the routing servers.

Note: this will not work with HTTPS since we need the Apache HTTP server to decode the S in HTTP for the routing engine :)

@datendelphin the Apache configs are not available so that's on you to ultimately fix this.