### PR TITLE
Update Dockerfile to include git

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ RUN mkdir -p /src
 COPY package.json /src
 
 # Install app dependencies
-RUN apk add --no-cache sed nodejs && \
+RUN apk add --no-cache sed nodejs git && \
     cd /src && \
     npm install
 

--- a/src/leaflet_options.js
+++ b/src/leaflet_options.js
@@ -24,17 +24,17 @@ module.exports = {
   },
   services: [{
     label: 'Car',
-    path: '/routed-car/route/v1',
+    path: 'https://routing.openstreetmap.de/routed-car/route/v1',
     debug: 'car',
   },
   {
     label: 'Bike',
-    path: '/routed-bike/route/v1',
+    path: 'https://routing.openstreetmap.de/routed-bike/route/v1',
     debug: 'bike',
   },
   {
     label: 'Foot',
-    path: '/routed-foot/route/v1',
+    path: 'https://routing.openstreetmap.de/routed-foot/route/v1',
     debug: 'foot',
   }],
   layer: [{


### PR DESCRIPTION
docker build fails because git is not installed inside the container where npm commands are run. Git is used in package.json on line 41 at:
"leaflet-routing-machine": "git+https://github.com/sosm/leaflet-routing-machine#b5690a3bc18686fa235e2d9e9d3069f70014a2a7",
